### PR TITLE
Updating JOSE editor guidelines

### DIFF
--- a/editing.md
+++ b/editing.md
@@ -1,9 +1,8 @@
-Editorial Guide
-===============
+# Editorial Guide
 
-The Journal of Open Source Software (JOSS) conducts all peer review and editorial processes in the open, on the GitHub issue tracker.
+The Journal of Open Source Education (JOSE) conducts all peer review and editorial processes in the open, on the GitHub issue tracker.
 
-JOSS editors manage the review workflow with the help of our bot, `@whedon`. The bot is summoned with commands typed directly on the GitHub review issues. For a list of commands, type: `@whedon commands`.
+JOSE editors manage the review workflow with the help of our bot, `@whedon`. The bot is summoned with commands typed directly on the GitHub review issues. For a list of commands, type: `@whedon commands`.
 
 ```eval_rst
 .. note:: To learn more about ``@whedon``'s functionalities, take a look at our `dedicated guide <whedon.html>`_.
@@ -14,7 +13,7 @@ JOSS editors manage the review workflow with the help of our bot, `@whedon`. The
 Once a submission comes in, it will be in the queue for a quick check by the Editor-in-chief (EiC). From there, it moves to a `PRE-REVIEW` issue, where the EiC will assign a handling editor, and the author can suggest reviewers. Initial direction to the authors for improving the paper can already happen here, especially if the paper lacks some requested sections.
 
 ```eval_rst
-.. important:: If the paper is out-of-scope for JOSS, editors assess this and notify the author in the ``PRE-REVIEW`` issue.
+.. important:: If the paper is out-of-scope for JOSE, editors assess this and notify the author in the ``PRE-REVIEW`` issue.
 ```
 
 The EiC assigns an editor (or a volunteering editor self-assigns) with the command `@whedon assign @username as editor` in a comment.
@@ -25,17 +24,17 @@ The EiC assigns an editor (or a volunteering editor self-assigns) with the comma
 
 ### How papers are assigned to editors
 
-By default, unless an editor volunteers, the Associated Editor-in-chief (AEiC) on duty will attempt to assign an incoming paper to the most suitable handling editor. While AEiCs will make every effort to match a submission with the most appropriate editor, there are a number of situations where an AEiC may assign a paper to an editor that doesn't fit entirely within the editor's research domains:
+By default, unless an editor volunteers, the Associate Editor-in-chief (AEiC) on duty will attempt to assign an incoming paper to the most suitable handling editor. While AEiCs will make every effort to match a submission with the most appropriate editor, there are a number of situations where an AEiC may assign a paper to an editor that doesn't fit entirely within the editor's research domains:
 
-- If there's no obvious fit to _any_ of the JOSS editors
+- If there's no obvious fit to _any_ of the JOSE editors
 - If the most suitable editor is already handling a large number of papers
 - If the chosen editor has a lighter editorial load than other editors
 
-In most cases, an AEiC will ask one or more editors to edit a submission (e.g. `@editor1, @editor 2 - would one of you be willing to edit this submission for JOSS`). If the editor doesn't respond within ~3 working days, the AEiC may assign the paper to the editor regardless.
+In most cases, an AEiC will ask one or more editors to edit a submission (e.g. `@editor1, @editor 2 - would one of you be willing to edit this submission for JOSE`). If the editor doesn't respond within ~3 working days, the AEiC may assign the paper to the editor regardless.
 
 ### Finding reviewers
 
-At this point, the handling editor's job is to identify reviewers who have sufficient expertise in the field of software and in the field of the submission. JOSS papers have to have a minimum of two reviewers per submission, except for papers that have previously been peer-reviewed via rOpenSci. In some cases, the editor also might want to formally add themself as one of the reviewers. If the editor feels particularly unsure of the submission, a third (or fourth) reviewer can be recruited.
+At this point, the handling editor's job is to identify reviewers who have sufficient expertise in the field of software and in the field of the submission. JOSE papers have to have a minimum of two reviewers per submission, except for papers that have previously been peer-reviewed via rOpenSci. In some cases, the editor also might want to formally add themselves as one of the reviewers. If the editor feels particularly unsure of the submission, a third (or fourth) reviewer can be recruited.
 
 To recruit reviewers, the handling editor can mention them in the `PRE-REVIEW` issue with their GitHub handle, ping them on Twitter, or email them. After expressing initial interest, candidate reviewers may need a longer explanation via email. See sample reviewer invitation email, below.
 
@@ -64,6 +63,7 @@ When the reviewers are satisfied with the improvements, we ask that they confirm
 When a submission is accepted, we ask that the authors create an archive (on [Zenodo](https://zenodo.org/), [fig**share**](https://figshare.com/), or other) and post the archive DOI in the `REVIEW` issue. The editor should run the command `@whedon set <archive doi> as archive`, and ping the EiC for final processing.
 
 Steps:
+
 - Get a new proof with the `@whedon generate pdf` command.
 - Download the proof, check all references have DOIs, follow the links and check the references.
   - Whedon can help check references with the command `@whedon check references`
@@ -72,7 +72,7 @@ Steps:
 - Check the Zenodo deposit has the correct metadata (title and author list), and request the author edit it if it doesn’t match the paper.
 - Run `@whedon set <doi> as archive`.
 - Run `@whedon set <v1.x.x> as version` if the version was updated.
-- Ping the `@openjournals/joss-eics` team on the review thread letting them know the paper is ready to be accepted.
+- Ping the `@openjournals/jose-eics` team on the review thread letting them know the paper is ready to be accepted.
 
 At that point, the EiC/AEiC will take over to publish the paper.
 
@@ -93,38 +93,25 @@ If a paper has already been reviewed and accepted by rOpenSci, the streamlined J
 
 ## Sample letter to invite reviewers
 
-```
-Dear Dr. Jekyll,
-
-I found you following links from the page of The Super Project and/or on Twitter. This
-message is to ask if you can help us out with a submission to JOSS (The Journal of Open
-Source Software), where I’m an editor.
-
-JOSS publishes articles about open source research software. The submission I'd like you
-to review is titled: "great software name here"
-
-and the submission repository is at: https://github.com/< … >
-
-JOSS is a free, open-source, community driven and developer-friendly online journal
-(no publisher is seeking to raise revenue from the volunteer labor of researchers!).
-
-The review process at JOSS is unique: it is open and author-reviewer-editor conversations
-are encouraged.
-
-JOSS reviews involve downloading and installing the software, and inspecting the repository
-and submitted paper for key elements. See https://joss.readthedocs.io/en/latest/review_criteria.html
-
-Editors and reviewers post comments on the Review issue, and authors respond to the comments
-and improve their submission until acceptance (or withdrawal, if they feel unable to
-satisfy the review).
-
-Would you be able to review this submission for JOSS? If not, can you recommend
-someone from your team to help out?
-
-Kind regards,
-
-JOSS Editor.
-```
+> Dear Dr. Jekyll,
+>
+> I found you following links from the page of The Super Project and/or on Twitter. This message is to ask if you can help us out with a submission to JOSE (The Journal of Open Source Education), where I’m an editor.
+>
+> JOSE publishes articles about open source research software. The submission I'd like you to review is titled: "great software name here" and the submission repository is at: `https://github.com/< … >`
+>
+> JOSE is a free, open-source, community driven and developer-friendly online journal (no publisher is seeking to raise revenue from the volunteer labor of researchers!).
+>
+> The review process at JOSE is unique: it is open and author-reviewer-editor conversations are encouraged.
+>
+> JOSE reviews involve downloading and installing the software, and inspecting the repository and submitted paper for key elements. See <https://openjournals.readthedocs.io/en/jose/review_criteria.html>
+>
+> Editors and reviewers post comments on the Review issue, and authors respond to the comments and improve their submission until acceptance (or withdrawal, if they feel unable to satisfy the review).
+>
+> Would you be able to review this submission for JOSE? If not, can you recommend someone from your team to help out?
+>
+> Kind regards,
+>
+> JOSE Editor
 
 ## Overview of editorial process
 
@@ -148,9 +135,9 @@ This doesn’t mean that you’re the editor, just that you’ve been suggested 
 
 **Step 6: The editor finds >= 2 reviewers**
 
-- Use the list of reviewers: type the command `@whedon list reviewers` or look at list of reviewers in a Google [spreadsheet](https://docs.google.com/spreadsheets/d/1PAPRJ63yq9aPC1COLjaQp8mHmEq3rZUzwUYxTulyu78/edit?usp=sharing)
-- If people are in the review list, the editor can @-mention them on the issue to see if they will review: e.g. `@person1 @person2 can you review this submission for JOSS?`
-- Or solicit reviewers outside the list. Send an email to people describing what JOSS is and asking if they would be interested in reviewing.
+- Use the list of reviewers: type the command `@whedon list reviewers` or look at list of reviewers in a Google [spreadsheet](https://docs.google.com/spreadsheets/d/1gQ_KZnJx-lyJwiuHBp9rE6b2ugMkJZzigvt4QLQHCH8/edit)
+- If people are in the review list, the editor can @-mention them on the issue to see if they will review: for example, `@person1 @person2 can you review this submission for JOSE?`
+- Or solicit reviewers outside the list. Send an email to people describing what JOSE is and asking if they would be interested in reviewing.
 
 **Step 7: Editor tells Whedon to assign the reviewer to the paper**
 
@@ -164,18 +151,18 @@ This doesn’t mean that you’re the editor, just that you’ve been suggested 
 **Step 8: Create the actual review issue**
 
 - Use `@whedon start review`
-- An issue is created with the review checklist, one per reviewer, e.g. https://github.com/openjournals/joss-reviews/issues/717
+- An issue is created with the review checklist, one per reviewer, for example, <https://github.com/openjournals/jose-reviews/issues/143>
 
 **Step 9: Close the pre-review issue**
 
-**Step 10: The actual JOSS review**
+**Step 10: The actual JOSE review**
 
 - The reviewer reviews the paper and has a conversation with the author. The editor lurks on this conversation and comes in if needed for questions (or CoC issues).
 - The reviewer potentially asks for changes and the author makes changes. Everyone agrees it’s ready.
 
 **Step 11: The editor pings the EiC team to get the paper published**
 
-- To get the paper published, ping the `@openjournals/joss-eics` team on the review thread letting them know the paper is ready to be accepted.
+- To get the paper published, ping the `@openjournals/jose-eics` team on the review thread letting them know the paper is ready to be accepted.
 
 **Step 12: Celebrate publication! Tweet! Thank reviewers! Say thank you on issue.**
 
@@ -183,7 +170,7 @@ This doesn’t mean that you’re the editor, just that you’ve been suggested 
 
 ![Editorial flow](images/JOSS-flowchart.png)
 
-## Expectations on JOSS editors
+## Expectations on JOSE editors
 
 ### Responding to editorial assignments
 
@@ -191,7 +178,7 @@ As documented above, usually, papers will be assigned to you by one of the AEiCs
 
 ### Continued attention to assigned submissions
 
-As an editor, part of your role is to ensure that submissions you're responsible for are progressing smoothly through the editorial process. This means that once or twice per week we ask that you check your GitHub notifications and/or your editorial dashboard (e.g. `http://joss.theoj.org/dashboard/youreditorname`) for updates to the papers you are handling.
+As an editor, part of your role is to ensure that submissions you're responsible for are progressing smoothly through the editorial process. This means that once or twice per week we ask that you check your GitHub notifications and/or your editorial dashboard (for example, `http://jose.theoj.org/dashboard/youreditorname`) for updates to the papers you are handling.
 
 **If reviews go stale**
 
@@ -205,14 +192,14 @@ Sometimes reviews go quiet, either because a reviewer has failed to complete the
 
 ## Out of office
 
-Sometimes we need time away from our editing duties at JOSS. The [joss-reviews](https://github.com/openjournals/joss-reviews) repository has the [OoO bot](https://github.com/swinton/probot-ooo) installed which means you can mark yourself as out of the office (and unable to respond to reviews) for a period of time e.g.:
+Sometimes we need time away from our editing duties at JOSE. The [jose-reviews](https://github.com/openjournals/jose-reviews) repository has the [OoO bot](https://github.com/swinton/probot-ooo) installed which means you can mark yourself as out of the office (and unable to respond to reviews) for a period of time.
 
-Mark yourself as OoO in one of the reviews you're editing in the [joss-reviews](https://github.com/openjournals/joss-reviews) repository like this:
+Mark yourself as OoO in one of the reviews you're editing in the [jose-reviews](https://github.com/openjournals/jose-reviews) repository like this:
 
 ```
 /ooo January 18 until February 2
 ```
 
-Ooo bot will then respond to any mentions in the [joss-reviews](https://github.com/openjournals/joss-reviews) repository to let people know you're away.
+Ooo bot will then respond to any mentions in the [jose-reviews](https://github.com/openjournals/jose-reviews) repository to let people know you're away.
 
-**Note, if you're planning on being out of the office for more than two weeks, please let the JOSS editorial team know.**
+**Note, if you're planning on being out of the office for more than two weeks, please let the JOSE editorial team know.**


### PR DESCRIPTION
The wording was all still for JOSS, so this update changes it to JOSE and the biggest thing is updating the reviewer spreadsheet link.