### PR TITLE
Shortened section title to fit on page width

### DIFF
--- a/submitting.md
+++ b/submitting.md
@@ -235,7 +235,7 @@ Submission to a preprint server is _not_ considered a previous publication.
 
 Purely financial (such as being named on an award) and organizational (such as general supervision of a research group) contributions are not considered sufficient for co-authorship of JOSS submissions, but active project direction and other forms of non-code contributions are. The authors themselves assume responsibility for deciding who should be credited with co-authorship, and co-authors must always agree to be listed. In addition, co-authors agree to be accountable for all aspects of the work, and to notify JOSS if any retraction or correction of mistakes are needed after publication.
 
-## Submissions using proprietary languages/dev environments
+## Proprietary languages/dev environments
 
 We strongly prefer software that doesn't rely upon proprietary (paid for) development environments/programming languages. However, provided _your submission meets our requirements_ (including having a valid open source license) then we will consider your submission for review. Should your submission be accepted for review, we may ask you, the submitting author, to help us find reviewers who already have the required development environment installed.
 


### PR DESCRIPTION
As the section title is too long, we get this unwanted effect, which in this exact situation adds an unwanted space underneath the section title.

Observed using Safari and Edge on macOS Sonoma 14.3.

I propose simply shortening the title, which also makes sense as all the other section titles are much shorter.

<img width="753" alt="Screenshot 2024-01-29 at 19 04 12" src="https://github.com/openjournals/docs/assets/29090665/fd3f3167-cf05-4413-abde-0e124f69201d">
